### PR TITLE
Querkraftnachweis Stütze ergänzt

### DIFF
--- a/Handnachweise/Beton.py
+++ b/Handnachweise/Beton.py
@@ -62,3 +62,39 @@ def platte_querkraft_normativ(v_xd, v_yd, m_xd, m_yd, m_xyd, m_xRd, m_yRd, f_sd,
     v_Rd_EL = k_d_EL * tau_cd * d_v 
     v_Rd_ZL = k_d_ZL * tau_cd * d_v
     return locals()
+
+## Querkraftnachweis rechteckige Stütze ohne Querkraftbewehrung (SIA262:2013 - 4.3.6.3)
+
+@handcalc(jupyter_display = True, precision=3,override='long')
+def platte_querkraftwiderstand_stuetze(h, tau_cd, f_cd, d_max, E_s, f_sd, c_nom, c_s, phi_x, phi_y, a_x, a_y, a, b, m_sdx, m_sdy, r_sx, r_sy, k_e):
+    
+    #phi_x, phi_y = Durchmesser der Bewehrung in x, y-Richtung
+    #a_x, a_y = Teilung der x, y-Bewehrung
+    #a, b = Abmessungen der Stütze
+
+    
+    k_g = (48) / (16+d_max) # 37
+        
+    d_x = h-c_nom-phi_x/2
+    d_y = h-c_nom-phi_x-phi_y/2
+
+    d_v = (d_x + d_y)/2-c_s # Fig. 20
+        
+    a_sx = (phi_x/2)**2*pi*1000/a_x #Bewehrungsquerschnitt in x-Richtung
+    a_sy = (phi_y/2)**2*pi*1000/a_y #Bewehrungsquerschnitt in y-Richtung
+            
+    m_Rdx = a_sx*f_sd*(d_x-a_sx*f_sd/(2*1000*f_cd))
+    m_Rdy = a_sy*f_sd*(d_y-a_sy*f_sd/(2*1000*f_cd))
+           
+    psi_x = 1.5 * r_sx / d_x * f_sd / E_s * (m_sdx/m_Rdx)**(3/2) # 59
+    psi_y = 1.5 * r_sy / d_y * f_sd / E_s * (m_sdy/m_Rdy)**(3/2) # 59
+        
+    k_rx = 1 / (0.45 + 0.18 * psi_x * d_x * k_g) # 58
+    k_ry = 1 / (0.45 + 0.18 * psi_y * d_y * k_g) # 58
+        
+    k_r = min(k_rx,k_ry) # Kleinerer Widerstand der beiden Richtungen
+
+    u_e = 2*(a+b)+d_v*pi # Umfang des Nachweisschnitts
+        
+    V_Rdc = k_r*tau_cd*d_v*u_e*k_e #57
+    return locals()


### PR DESCRIPTION
Hallo Pascal

Hier nun der zweite Anlauf meine Methode zu deinem Repository hinzuzufügen. Es handelt sich um den Querkraftnachweis einer rechteckige Stütze ohne Querkraftbewehrung (SIA262:2013 - 4.3.6.3).  Ich habe das Ganze noch nicht mit Einheiten (forallpeople) probiert. Evtl. sollten wir das mal zusammen anschauen, bevor du es in deinem Repository aufnimmst. 

LG - Lucas